### PR TITLE
Enhance error handling in ShellCommandExecutor and improve command execution in mongo-buddy

### DIFF
--- a/rustic-mongo-buddy/Dockerfile
+++ b/rustic-mongo-buddy/Dockerfile
@@ -23,11 +23,10 @@ ARG MONGO_TOOLS_VERSION=100.14.0
 WORKDIR /app
 
 # Install mongodb-database-tools and zstd for compression
+# Direct .deb download avoids the MongoDB APT repo, whose SHA1-signed key is
+# rejected by Debian Trixie (sqv policy changed 2026-02-01).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates wget gnupg zstd \
-    && wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/mongodb.gpg] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" > /etc/apt/sources.list.d/mongodb.list \
-    && apt-get update \
+    ca-certificates wget zstd \
     && wget -q https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-arm64-${MONGO_TOOLS_VERSION}.deb \
     && dpkg -i mongodb-database-tools-ubuntu2204-arm64-${MONGO_TOOLS_VERSION}.deb || true \
     && apt-get install -f -y --no-install-recommends \

--- a/rustic-mongo-buddy/src/mongo_data_exporter.rs
+++ b/rustic-mongo-buddy/src/mongo_data_exporter.rs
@@ -241,7 +241,9 @@ impl MongoDataExporter {
             "tar {} {archived_dump} -C {local_output_folder} .",
             Self::ZSTD_ARCHIVE_OPTIONS,
         );
-        ShellCommandExecutor::execute_cmd(archive_command, None).await;
+        ShellCommandExecutor::execute_cmd(archive_command, None)
+            .await
+            .expect("Failed to archive dump");
         info!("Archived dump: {archived_dump}");
     }
 
@@ -262,7 +264,9 @@ impl MongoDataExporter {
         );
 
         let mongo_dump_command = command_parts.join(" ");
-        ShellCommandExecutor::execute_cmd(&mongo_dump_command, None).await;
+        ShellCommandExecutor::execute_cmd(&mongo_dump_command, None)
+            .await
+            .expect("Failed to run mongodump");
         info!("Mongo dump finished!");
     }
 }

--- a/rustic-mongo-buddy/src/mongo_data_importer.rs
+++ b/rustic-mongo-buddy/src/mongo_data_importer.rs
@@ -56,8 +56,13 @@ impl MongoDataImporter {
         let mongo_host = self.mongo_uri.split('@').collect::<Vec<_>>()[1];
 
         info!("Importing {extracted_mongo_files_location} to {mongo_host}");
-        self.execute_mongo_restore(extracted_mongo_files_location)
-            .await;
+        if let Err(e) = self
+            .execute_mongo_restore(extracted_mongo_files_location)
+            .await
+        {
+            error!("mongorestore failed: {e}");
+            return;
+        }
 
         info!("Deleting tar file {compressed_mongo_dataset}");
         std::fs::remove_file(compressed_mongo_dataset).expect("Failed to remove tar file");
@@ -129,10 +134,15 @@ impl MongoDataImporter {
             extracted_mongo_files_location.into()
         );
 
-        ShellCommandExecutor::execute_cmd(&untar_command, None).await;
+        ShellCommandExecutor::execute_cmd(&untar_command, None)
+            .await
+            .expect("Failed to extract archive");
     }
 
-    async fn execute_mongo_restore(&self, mongo_data_folder: impl Into<String>) {
+    async fn execute_mongo_restore(
+        &self,
+        mongo_data_folder: impl Into<String>,
+    ) -> Result<(), String> {
         let ns_to = if !self.override_destination_database_name.is_empty() {
             self.override_destination_database_name.to_string()
         } else {
@@ -181,6 +191,6 @@ impl MongoDataImporter {
         ];
 
         let mongo_restore_command = mongo_restore_commands.join(" ");
-        ShellCommandExecutor::execute_cmd(&mongo_restore_command, Some(true)).await;
+        ShellCommandExecutor::execute_cmd(&mongo_restore_command, Some(true)).await
     }
 }

--- a/rustic-shell/src/shell_command_executor.rs
+++ b/rustic-shell/src/shell_command_executor.rs
@@ -1,18 +1,22 @@
 use std::process::Stdio;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tracing::info;
+use tracing::{error, info};
 
 pub struct ShellCommandExecutor;
 
 impl ShellCommandExecutor {
-    pub async fn execute_cmd(cmd_for_execution: impl AsRef<str>, check_for_error: Option<bool>) {
+    pub async fn execute_cmd(
+        cmd_for_execution: impl AsRef<str>,
+        check_for_error: Option<bool>,
+    ) -> Result<(), String> {
         let check_for_error = check_for_error.unwrap_or(false);
         let mut restore_cmd = tokio::process::Command::new("sh");
 
         restore_cmd.arg("-c");
         restore_cmd.arg(cmd_for_execution.as_ref());
         restore_cmd.stdout(Stdio::piped());
+        restore_cmd.stderr(Stdio::piped());
 
         let mut child = restore_cmd
             .spawn()
@@ -25,21 +29,62 @@ impl ShellCommandExecutor {
             )
         });
 
-        let mut reader = BufReader::new(stdout).lines();
-
-        tokio::spawn(async move {
-            _ = child
-                .wait()
-                .await
-                .expect("child process encountered an error");
+        let stderr = child.stderr.take().unwrap_or_else(|| {
+            panic!(
+                "child did not have a handle to stderr for {}",
+                cmd_for_execution.as_ref()
+            )
         });
 
-        while let Some(line) = reader.next_line().await.unwrap() {
-            if check_for_error && line.to_lowercase().contains("error") {
-                panic!("{line}");
-            } else {
-                info!("{line}");
+        let mut stdout_reader = BufReader::new(stdout).lines();
+        let mut stderr_reader = BufReader::new(stderr).lines();
+
+        let mut stderr_lines: Vec<String> = Vec::new();
+
+        loop {
+            tokio::select! {
+                line = stdout_reader.next_line() => {
+                    match line.unwrap() {
+                        Some(line) => {
+                            if check_for_error && line.to_lowercase().contains("error") {
+                                error!("{line}");
+                                return Err(line);
+                            } else {
+                                info!("{line}");
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                line = stderr_reader.next_line() => {
+                    if let Some(line) = line.unwrap() {
+                        error!("{line}");
+                        stderr_lines.push(line);
+                    }
+                }
             }
         }
+
+        // Drain remaining stderr after stdout closes
+        while let Some(line) = stderr_reader.next_line().await.unwrap() {
+            error!("{line}");
+            stderr_lines.push(line);
+        }
+
+        let status = child
+            .wait()
+            .await
+            .expect("child process encountered an error");
+
+        if !status.success() {
+            let msg = if stderr_lines.is_empty() {
+                format!("command exited with status {status}")
+            } else {
+                stderr_lines.join("\n")
+            };
+            return Err(msg);
+        }
+
+        Ok(())
     }
 }

--- a/rustic-target-db/src/target_db_preparator.rs
+++ b/rustic-target-db/src/target_db_preparator.rs
@@ -43,7 +43,9 @@ impl TargetDbPreparator {
             db_name = cdc_operator_snapshot_payload.source_postgres_url(),
         );
 
-        ShellCommandExecutor::execute_cmd(&dump_command, None).await
+        ShellCommandExecutor::execute_cmd(&dump_command, None)
+            .await
+            .expect("Failed to run pg_dump");
     }
 
     /// Asynchronously drops a schema from the target PostgreSQL database.
@@ -123,7 +125,9 @@ impl TargetDbPreparator {
             db_name = cdc_operator_snapshot_payload.target_postgres_url(),
         );
 
-        ShellCommandExecutor::execute_cmd(&restore_command, None).await;
+        ShellCommandExecutor::execute_cmd(&restore_command, None)
+            .await
+            .expect("Failed to run pg_restore");
 
         // Remove the pg_dump.sql file
         debug!("{}", "Removing {PG_DUMP_FILE_NAME} file".bold().green());


### PR DESCRIPTION
 ### Fix silent failure on mongorestore errors

 ShellCommandExecutor now captures _stderr_ alongside _stdout_ and checks the process exit code, returning a Result<(), String> on failure. Previously, errors written to stderr (e.g. error connecting to host) were invisible to the executor, and a non-zero exit code was silently ignored — causing the import to appear successful while restoring nothing.