### PR TITLE
Fix embedded null byte failure in inserts + Rust 1.95 bump

### DIFF
--- a/.github/workflows/format-workflow.yaml
+++ b/.github/workflows/format-workflow.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  RUST_VERSION: 1.92.0
+  RUST_VERSION: 1.95.0
 
 permissions:
   contents: read

--- a/.github/workflows/tests-workflow.yaml
+++ b/.github/workflows/tests-workflow.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  RUST_VERSION: 1.92.0
+  RUST_VERSION: 1.95.0
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.92.0
+ARG RUST_VERSION=1.95.0
 ARG IMAGE_NAME="public.ecr.aws/docker/library/rust:${RUST_VERSION}-slim-bookworm"
 
 # Build the actual app

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.95.0"
 components = ["rustc", "rustfmt", "cargo", "clippy"]
 
 [target.aarch64-apple-darwin]

--- a/rustic-anonymization-config/src/config_structs/table_struct.rs
+++ b/rustic-anonymization-config/src/config_structs/table_struct.rs
@@ -9,4 +9,5 @@ pub struct AnonymizationConfigTable {
     pub anonymization_type: AnonymizationConfigTableType,
     pub keep_num_of_records: Option<usize>,
     pub filter_type: Option<FilterType>,
+    pub sanitize_null_bytes: Option<bool>,
 }

--- a/rustic-anonymization-operator/src/anonymization_dataframe_operator.rs
+++ b/rustic-anonymization-operator/src/anonymization_dataframe_operator.rs
@@ -7,9 +7,8 @@ use aws_sdk_s3::primitives::ByteStream;
 use dms_cdc_operator::dataframe::dataframe_ops::CreateDataframePayload;
 use dms_cdc_operator::dataframe::dataframe_ops::DataframeOperator;
 use polars::prelude::IntoLazy;
-use polars::prelude::col;
-use polars::prelude::lit;
 use polars::prelude::{DataFrame, ParquetWriter};
+use polars::prelude::{DataType, Expr, col, lit};
 use polars::{
     io::SerReader as _,
     prelude::{ParallelStrategy, ParquetReader},
@@ -139,6 +138,16 @@ impl DataframeOperator for AnonymizationDataFrameOperator<'_> {
             "{table} parquet file loaded! Time taken: {df_load_duration}",
             table = &payload.table_name,
         );
+
+        let df = if table_config
+            .and_then(|c| c.sanitize_null_bytes)
+            .unwrap_or(false)
+        {
+            info!("Sanitizing null bytes for table: {}", &payload.table_name);
+            sanitize_null_bytes(df)?
+        } else {
+            df
+        };
 
         // Filter [DataFrame] based on the filter type,
         // if any was supplied.
@@ -315,6 +324,28 @@ impl DataframeOperator for AnonymizationDataFrameOperator<'_> {
 
         Ok(Some(df))
     }
+}
+
+// Strip embedded null bytes (\x00) from all String columns.
+// PostgreSQL rejects strings containing null bytes, but they can appear
+// in source data and survive the Parquet round-trip.
+fn sanitize_null_bytes(df: DataFrame) -> Result<DataFrame> {
+    let exprs: Vec<Expr> = df
+        .get_columns()
+        .iter()
+        .filter(|s| matches!(s.dtype(), DataType::String))
+        .map(|s| {
+            col(s.name().as_str())
+                .str()
+                .replace_all(lit("\x00"), lit(""), true)
+        })
+        .collect();
+
+    if exprs.is_empty() {
+        return Ok(df);
+    }
+
+    Ok(df.lazy().with_columns(exprs).collect()?)
 }
 
 // Copy Parquet file to anonymized S3 bucket.

--- a/rustic-config-generator-cli/src/main.rs
+++ b/rustic-config-generator-cli/src/main.rs
@@ -135,6 +135,7 @@ fn main() -> Result<()> {
         anonymization_type: anonymization_config_table_type,
         keep_num_of_records: None,
         filter_type: None,
+        sanitize_null_bytes: None,
     };
 
     // Drop table if it exists

--- a/rustic-mongo-buddy/Dockerfile
+++ b/rustic-mongo-buddy/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.92.0
+ARG RUST_VERSION=1.95.0
 ARG IMAGE_NAME="public.ecr.aws/docker/library/rust:${RUST_VERSION}-slim-trixie"
 
 # Build the actual app

--- a/rustic-mongo-buddy/rust-toolchain.toml
+++ b/rustic-mongo-buddy/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.95.0"
 components = ["rustc", "rustfmt", "cargo", "clippy"]
 
 [target.aarch64-apple-darwin]


### PR DESCRIPTION
Fix embedded null byte failure in inserts + Rust 1.95 bump

  - Investigated a PostgreSQL insert failure caused by an embedded \x00 in the task_history.metadata column — traced to a large base64-encoded blob stored directly in source PostgreSQL that AWS DMS exports to Parquet
  - Added sanitize_null_bytes: Option<bool> field to AnonymizationConfigTable config struct, allowing opt-in null byte stripping per table
  - Implemented sanitize_null_bytes() in AnonymizationDataFrameOperator using Polars lazy API to replace \x00 in all String columns — zero overhead for tables that don't opt in
  - Bumped Rust toolchain to 1.95.0